### PR TITLE
Moving onboarders to opent2terror

### DIFF
--- a/org.opent2t.onboarding.insteon/js/thingOnboarding.js
+++ b/org.opent2t.onboarding.insteon/js/thingOnboarding.js
@@ -1,6 +1,8 @@
 'use strict';
 var request = require('request-promise');
 var OpenT2TLogger = require('opent2t').Logger;
+var OpenT2TError = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 class Onboarding {
     constructor(logLevel = "info") { 
@@ -8,6 +10,11 @@ class Onboarding {
     }
     
     onboard(authInfo) {
+        // Ensure getUserInput and getDeveloperInput answers are present
+        if (!authInfo || authInfo.length < 2) {
+            throw new OpenT2TError(401, OpenT2TConstants.InvalidAuthInput);
+        }
+        
         this.ConsoleLogger.info('Onboarding Insteon Hub');
 
         // this comes from the onboardFlow property 
@@ -54,12 +61,6 @@ class Onboarding {
                 };
 
                 return authTokens;
-            })
-            .catch(function (err) {
-                this.ConsoleLogger.error(`Request failed to: ${options.method}- ${options.url}`);
-                this.ConsoleLogger.error(`Error : ${err.statusCode} - ${err.response.statusMessage}`);
-                // todo auto refresh in specific cases, issue 74
-                request.reject(err);
             });
     }
 }

--- a/org.opent2t.onboarding.nest/js/thingOnboarding.js
+++ b/org.opent2t.onboarding.nest/js/thingOnboarding.js
@@ -1,6 +1,8 @@
 'use strict';
 var request = require('request-promise');
 var OpenT2TLogger = require('opent2t').Logger;
+var OpenT2TError = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 class Onboarding {
     constructor(logLevel = "info") { 
@@ -8,6 +10,11 @@ class Onboarding {
     }
 
     onboard(authInfo) {
+        // Ensure getUserInput and getDeveloperInput answers are present
+        if (!authInfo || authInfo.length < 2) {
+            throw new OpenT2TError(401, OpenT2TConstants.InvalidAuthInput);
+        }
+        
         this.ConsoleLogger.info('Onboarding Nest Hub');
 
         // this comes from the onboardFlow property 
@@ -49,12 +56,6 @@ class Onboarding {
                 }
                 
                 return authTokens;
-            })
-            .catch(function (err) {
-                this.ConsoleLogger.error(`Request failed to: ${options.method}- ${options.url}`);
-                this.ConsoleLogger.error(`Error : ${err.statusCode} - ${err.response.statusMessage}`);
-                // todo auto refresh in specific cases, issue 74
-                request.reject(err);
             });
     }
 }

--- a/org.opent2t.onboarding.smartthings/js/thingOnboarding.js
+++ b/org.opent2t.onboarding.smartthings/js/thingOnboarding.js
@@ -1,6 +1,8 @@
 'use strict';
 var request = require('request-promise');
 var OpenT2TLogger = require('opent2t').Logger;
+var OpenT2TError = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 class Onboarding {
     constructor(logLevel = "info") { 
@@ -8,6 +10,11 @@ class Onboarding {
     }
 
     onboard(authInfo) {
+        // Ensure getUserInput and getDeveloperInput answers are present
+        if (!authInfo || authInfo.length < 2) {
+            throw new OpenT2TError(401, OpenT2TConstants.InvalidAuthInput);
+        }
+
         this.ConsoleLogger.info('Onboarding SmartThings Hub');
 
         // this comes from the onboardFlow property 
@@ -53,12 +60,6 @@ class Onboarding {
                 };
                 
                 return authTokens;
-            })
-            .catch(function (err) {
-                this.ConsoleLogger.error(`Request failed to: ${options.method}- ${options.url}`);
-                this.ConsoleLogger.error(`Error : ${err.statusCode} - ${err.response.statusMessage}`);
-                // todo auto refresh in specific cases, issue 74
-                request.reject(err);
             });
     }
 }

--- a/org.opent2t.onboarding.winkhub/js/thingOnboarding.js
+++ b/org.opent2t.onboarding.winkhub/js/thingOnboarding.js
@@ -4,6 +4,8 @@
 'use strict';
 var request = require('request-promise');
 var OpenT2TLogger = require('opent2t').Logger;
+var OpenT2TError = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 class Onboarding { 
     constructor(logLevel = "info") {
@@ -11,6 +13,11 @@ class Onboarding {
     }
    
     onboard(authInfo) {
+        // Ensure getUserInput and getDeveloperInput answers are present
+        if (!authInfo || authInfo.length < 2) {
+            throw new OpenT2TError(401, OpenT2TConstants.InvalidAuthInput);
+        }
+
         this.ConsoleLogger.verbose("Onboarding Wink Hub");
 
         // this comes from the onboardFlow property 
@@ -64,12 +71,6 @@ class Onboarding {
                 };
                 
                 return authTokens;
-            })
-            .catch(function (err) {
-                this.ConsoleLogger.error(`Request failed to: ${options.method}- ${options.url}`);
-                this.ConsoleLogger.error(`Error : ${err.statusCode} - ${err.response.statusMessage}`);
-                // todo auto refresh in specific cases, issue 74
-                request.reject(err);
             });
     }
 }


### PR DESCRIPTION
These changes are already merged with the changes in https://github.com/openT2T/onboarding/pull/33, so they'll look larger than they are until that PR gets accepted.  I think when that happens the diffs will be cleaner, but I'm keeping my fingers crossed that git knows the commits are the same.

Existing onboarders are simple, so didn't actually throw any errors.

I added validation that authInfo is at least present, which also ensures that OpenT2TEreor and OpenT2TConstants can be required without running into an unused vars issue, so they'll be available if we go and add any additional error cases.

I removed the same code from each onboarder, where we were simply login a failure and rejecting.  Instead, we should just allow the rejection to bubble up where it will be converted into an OpenT2TError later.