### PR TITLE
Ask user permission dynamic url support

### DIFF
--- a/org.opent2t.onboarding.insteon/js/package.json
+++ b/org.opent2t.onboarding.insteon/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-onboarding-org-opent2t-onboarding-insteon",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Onboarding for Insteon",
   "license": "MIT",
   "main": "thingOnboarding.js",

--- a/org.opent2t.onboarding.nest/js/package.json
+++ b/org.opent2t.onboarding.nest/js/package.json
@@ -20,9 +20,10 @@
    "dependencies": {
      "request": "^2.74.0",
      "request-promise": "^4.1.1",
-     "opent2t": "^1.0.4"
+     "opent2t": "^1.0.4",
+     "querystring": "^0.2.0"
    },
    "devDependencies": {
-     "ava": "^0.15.2"
+     "ava": "^0.18.2"
    }
  }

--- a/org.opent2t.onboarding.nest/js/package.json
+++ b/org.opent2t.onboarding.nest/js/package.json
@@ -1,6 +1,6 @@
 {
    "name": "opent2t-onboarding-org-opent2t-onboarding-nest",
-   "version": "0.2.3",
+   "version": "0.2.4",
    "description": "Onboarding for Nest",
    "license": "MIT",
    "main": "thingOnboarding.js",

--- a/org.opent2t.onboarding.smartthings/js/package.json
+++ b/org.opent2t.onboarding.smartthings/js/package.json
@@ -1,6 +1,6 @@
 {
    "name": "opent2t-onboarding-org-opent2t-onboarding-smartthings",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "description": "Onboarding for SmartThings",
    "license": "MIT",
    "main": "thingOnboarding.js",

--- a/org.opent2t.onboarding.smartthings/js/package.json
+++ b/org.opent2t.onboarding.smartthings/js/package.json
@@ -20,9 +20,10 @@
    "dependencies": {
      "request": "^2.74.0",
      "request-promise": "^4.1.1",
-     "opent2t": "^1.0.4"
+     "opent2t": "^1.0.4",
+     "querystring": "^0.2.0"
    },
    "devDependencies": {
-     "ava": "^0.15.2"
+     "ava": "^0.18.2"
    }
  }

--- a/org.opent2t.onboarding.smartthings/js/thingOnboarding.js
+++ b/org.opent2t.onboarding.smartthings/js/thingOnboarding.js
@@ -1,5 +1,7 @@
 'use strict';
 var request = require('request-promise');
+var url = require('url');
+var querystring = require('querystring');
 var OpenT2TLogger = require('opent2t').Logger;
 var OpenT2TError = require('opent2t').OpenT2TError;
 var OpenT2TConstants = require('opent2t').OpenT2TConstants;
@@ -7,26 +9,33 @@ var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 class Onboarding {
     constructor(logLevel = "info") { 
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
+        this.authUrl = "https://graph.api.smartthings.com/oauth";
     }
 
     onboard(authInfo) {
-        // Ensure getUserInput and getDeveloperInput answers are present
+        // Ensure getDeveloperInput (0) and askUserPermission (1) answers are present
         if (!authInfo || authInfo.length < 2) {
             throw new OpenT2TError(401, OpenT2TConstants.InvalidAuthInput);
         }
 
         this.ConsoleLogger.info('Onboarding SmartThings Hub');
 
+        // Parse authInfo[1] to get the query parameters, SmartThings wants 'code'
+        var code = url.parse(authInfo[1], true).query['code'];
+
         // this comes from the onboardFlow property 
         // as part of the schema and manifest.xml
-        var params = 'grant_type=authorization_code&client_id=' + authInfo[0].client_id
-                   + '&client_secret=' + authInfo[0].client_secret
-                   + '&redirect_uri=' + authInfo[0].redirect_url
-                   + '&code=' + authInfo[1]
-                   + '&scope=app';
+        var params = {
+            client_id: authInfo[0].client_id,
+            client_secret: authInfo[0].client_secret,
+            redirect_uri: authInfo[0].redirect_url,
+            code: code,
+            scope: 'app',
+            grant_type: 'authorization_code'
+        }
 
         // build request URI
-        var requestUri = 'https://graph.api.smartthings.com/oauth/token?' + params;
+        var requestUri = this.authUrl + '/token?' + querystring.stringify(params);
         var method = 'POST';
 
         // Set the headers
@@ -61,6 +70,24 @@ class Onboarding {
                 
                 return authTokens;
             });
+    }
+
+    /**
+     * Gets the verification URI for the user to visit, and connect the client_id
+     * with their account, as per oAuth2
+     */
+    getUserVerificationUri(authInfo) {
+        var parameters = {
+            client_id: authInfo[0].client_id,
+            redirect_uri: authInfo[0].redirect_url,
+            scope: 'app',
+            response_type: 'code'
+        };
+
+        // Automatically encode/escape any of the parameters for use in the URL
+        let fullUrl = this.authUrl + '/authorize?' + querystring.stringify(parameters);
+
+        return Promise.resolve(fullUrl);
     }
 }
 

--- a/org.opent2t.onboarding.winkhub/js/package.json
+++ b/org.opent2t.onboarding.winkhub/js/package.json
@@ -1,6 +1,6 @@
 {
    "name": "opent2t-onboarding-org-opent2t-onboarding-winkhub",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "description": "Onboarding for Wink",
    "license": "MIT",
    "main": "thingOnboarding.js",


### PR DESCRIPTION
Adds dynamic url support to the askUserPermission onboarding flow for Nest and SmartThings.

Fully backwards compatible with the old version, the new methods will only be used if the manifest.xml for the hub translators is modified.